### PR TITLE
Add French dictation locale

### DIFF
--- a/locale/fr-fr/dialogs/already_dictating.dialog
+++ b/locale/fr-fr/dialogs/already_dictating.dialog
@@ -1,0 +1,1 @@
+La dictée est déjà activée.

--- a/locale/fr-fr/dialogs/dictation.dialog
+++ b/locale/fr-fr/dialogs/dictation.dialog
@@ -1,0 +1,2 @@
+Je lis la dernière dictée.
+La dernière dictée était :

--- a/locale/fr-fr/dialogs/not_dictating.dialog
+++ b/locale/fr-fr/dialogs/not_dictating.dialog
@@ -1,0 +1,1 @@
+Je ne suis pas en train de dicter en ce moment.

--- a/locale/fr-fr/dialogs/start.dialog
+++ b/locale/fr-fr/dialogs/start.dialog
@@ -1,0 +1,2 @@
+La dictée est activée.
+D'accord, je suis prêt pour la dictée.

--- a/locale/fr-fr/dialogs/stop.dialog
+++ b/locale/fr-fr/dialogs/stop.dialog
@@ -1,0 +1,1 @@
+La dictée est arrêtée.

--- a/locale/fr-fr/intents/StopKeyword.voc
+++ b/locale/fr-fr/intents/StopKeyword.voc
@@ -1,0 +1,3 @@
+annule
+arrête
+stop

--- a/locale/fr-fr/intents/start_dictation.intent
+++ b/locale/fr-fr/intents/start_dictation.intent
@@ -1,0 +1,15 @@
+active la dictée
+active la dictée sous le nom {name}
+active la transcription
+commence la dictée
+commence la dictée sous le nom {name}
+commence à prendre des notes
+commence à prendre des notes sous le nom {name}
+démarre la dictée
+démarre la dictée nommée {name}
+démarre la transcription
+enregistre ce que je dicte
+lance la dictée
+lance la dictée sous le nom {name}
+prends des notes
+prends des notes sous le nom {name}

--- a/locale/fr-fr/intents/stop_dictation.intent
+++ b/locale/fr-fr/intents/stop_dictation.intent
@@ -1,0 +1,10 @@
+arrête la dictée
+arrête la transcription
+termine la dictée
+termine la transcription
+désactive la dictée
+désactive la transcription
+arrête de prendre des notes
+cesse la dictée
+stoppe la dictée
+stoppe la transcription

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,13 @@
+{
+  "skill_id": "ovos-skill-dictation.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-dictation",
+  "name": "Skill de dictée",
+  "description": "Transcrit en continu la parole de l'utilisateur dans un fichier texte tant que la dictée est activée.",
+  "examples": [
+    "Démarre la dictée",
+    "Arrête la dictée"
+  ],
+  "tags": [
+    "productivité"
+  ]
+}

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,8 +1,8 @@
 {
   "skill_id": "ovos-skill-dictation.openvoiceos",
   "source": "https://github.com/OpenVoiceOS/ovos-skill-dictation",
-  "name": "Skill de dictée",
-  "description": "Transcrit en continu la parole de l'utilisateur dans un fichier texte tant que la dictée est activée.",
+  "name": "Dictée",
+  "description": "Transcrit ce que vous dites tant que la dictée est active.",
   "examples": [
     "Démarre la dictée",
     "Arrête la dictée"


### PR DESCRIPTION
## Summary
- add a complete French locale tree for dictation dialogs, intents, and metadata
- use shorter natural French utterances instead of bulk translated intent lists

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON