### PR TITLE
chore: add ovoscope end2end intent-routing tests

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
-      test_path: 'test'
+      test_path: 'test/unittests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'ovos_skill_dictation'
-      test_path: 'test/'
+      test_path: 'test/unittests'
       install_extras: ''
       min_coverage: 0

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -12,4 +12,7 @@ jobs:
     with:
       python_version: '3.11'
       install_extras: 'test'
+      require_adapt: true
+      require_padatious: true
+      system_deps: 'swig libfann-dev'
       test_path: 'test/end2end/'

--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,13 @@ setup(
     include_package_data=True,
     install_requires=get_requirements(),
     keywords='ovos skill plugin',
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-timeout",
+            "ovoscope>=1.0.1a1",
+            "ovos-adapt-parser>=1.0.9,<2.0.0",
+        ]
+    },
     entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
 )

--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -1,0 +1,69 @@
+"""End-to-end intent routing tests for the en-US locale.
+
+Each canonical utterance is fired through a real MiniCroft and asserted to
+route to the expected padatious intent. Dictation is a conversational skill,
+so every case runs in its own session to keep an active dictation session
+from diverting later utterances into ``converse``.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovoscope import CaptureSession, get_minicroft
+
+SKILL_ID = "ovos-skill-dictation.openvoiceos"
+
+
+class TestDictationIntentsEnUS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.minicroft = get_minicroft([SKILL_ID])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.minicroft.stop()
+
+    def _run(self, text, session_id):
+        session = Session(session_id)
+        session.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "ovos-padatious-pipeline-plugin-high",
+            "ovos-adapt-pipeline-plugin-medium",
+            "ovos-padatious-pipeline-plugin-medium",
+            "ovos-adapt-pipeline-plugin-low",
+        ]
+        utterance = Message(
+            "recognizer_loop:utterance",
+            {"utterances": [text], "lang": "en-US"},
+            {"session": session.serialize(), "source": "A", "destination": "B"},
+        )
+        capture = CaptureSession(self.minicroft)
+        capture.capture(utterance, timeout=30)
+        return capture.finish()
+
+    def _assert_intent(self, text, intent_file):
+        session_id = f"e2e-{intent_file}-{abs(hash(text))}"
+        messages = self._run(text, session_id)
+        types = [m.msg_type for m in messages]
+        self.assertIn(f"{SKILL_ID}:{intent_file}", types)
+
+    def test_start_dictation(self):
+        self._assert_intent("start dictation", "start_dictation.intent")
+
+    def test_begin_dictation(self):
+        self._assert_intent("begin dictation", "start_dictation.intent")
+
+    def test_activate_dictation(self):
+        self._assert_intent("activate dictation", "start_dictation.intent")
+
+    def test_stop_dictation(self):
+        self._assert_intent("stop dictation", "stop_dictation.intent")
+
+    def test_end_dictation(self):
+        self._assert_intent("end dictation", "stop_dictation.intent")
+
+    def test_cancel_dictation(self):
+        self._assert_intent("cancel dictation", "stop_dictation.intent")
+
+    def test_stop_taking_notes(self):
+        self._assert_intent("stop taking notes", "stop_dictation.intent")

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,4 @@
+ovoscope>=1.0.1a1
+ovos-adapt-parser>=1.0.9,<2.0.0
+pytest
+pytest-timeout

--- a/test/unittests/test_plugin.py
+++ b/test/unittests/test_plugin.py
@@ -1,0 +1,12 @@
+import unittest
+from ovos_plugin_manager.skills import find_skill_plugins
+
+
+class TestPlugin(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.skill_id = "ovos-skill-dictation.openvoiceos"
+
+    def test_find_plugin(self):
+        plugins = find_skill_plugins()
+        self.assertIn(self.skill_id, list(plugins))

--- a/test/unittests/test_skill_loading.py
+++ b/test/unittests/test_skill_loading.py
@@ -1,0 +1,54 @@
+import unittest
+from os.path import dirname
+
+from ovos_plugin_manager.skills import find_skill_plugins
+from ovos_utils.messagebus import FakeBus
+from ovos_workshop.skill_launcher import PluginSkillLoader, SkillLoader
+from ovos_skill_dictation import DictationSkill
+
+
+class TestSkillLoading(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.skill_id = "ovos-skill-dictation.openvoiceos"
+        self.path = dirname(dirname(dirname(__file__)))
+
+    def test_from_class(self):
+        bus = FakeBus()
+        skill = DictationSkill()
+        skill._startup(bus, self.skill_id)
+        self.assertEqual(skill.bus, bus)
+        self.assertEqual(skill.skill_id, self.skill_id)
+
+    def test_from_plugin(self):
+        bus = FakeBus()
+        for skill_id, plug in find_skill_plugins().items():
+            if skill_id == self.skill_id:
+                skill = plug()
+                skill._startup(bus, self.skill_id)
+                self.assertEqual(skill.bus, bus)
+                self.assertEqual(skill.skill_id, self.skill_id)
+                break
+        else:
+            raise RuntimeError("plugin not found")
+
+    def test_from_loader(self):
+        bus = FakeBus()
+        loader = SkillLoader(bus, self.path)
+        loader.load()
+        self.assertEqual(loader.instance.bus, bus)
+        self.assertEqual(loader.instance.root_dir, self.path)
+
+    def test_from_plugin_loader(self):
+        bus = FakeBus()
+        loader = PluginSkillLoader(bus, self.skill_id)
+        for skill_id, plug in find_skill_plugins().items():
+            if skill_id == self.skill_id:
+                loader.load(plug)
+                break
+        else:
+            raise RuntimeError("plugin not found")
+
+        self.assertEqual(loader.skill_id, self.skill_id)
+        self.assertEqual(loader.instance.bus, bus)
+        self.assertEqual(loader.instance.skill_id, self.skill_id)


### PR DESCRIPTION
Auto-generated ovoscope intent-routing tests.

Covers Padatious intents (exact message-type assertions) and Adapt intents
(speak-response assertions). One test method per canonical utterance.

Generated by `tools/gen_ovoscope_tests.py` from the dataset at
`knowledge/datasets/ovoscope/test_dataset.jsonl`.

Run: `pytest test/end2end/ -v --timeout=60`