### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Dictation skill
 
-continuously transcribes user speech to text file while enabled, made for [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener)
+This skill transcribes user speech to a text file while it is active. It is made for [OpenVoiceOS/ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener).
 
-A similar skill that records audio instead of text transcriptions is [OpenVoiceOS/skill-ovos-audio-recording](https://github.com/OpenVoiceOS/skill-ovos-audio-recording)
+A related skill, [OpenVoiceOS/skill-ovos-audio-recording](https://github.com/OpenVoiceOS/skill-ovos-audio-recording), records audio instead of text transcriptions.
 
 ## About
 
-captures utterances and disables wake words while active
+The skill captures utterances and disables wake words while dictation is active.
 
 - start dictation
   - enable continuous conversation mode
-  - capture all utterances in converse method
+  - capture all utterances in the converse method
 - converse
-  - display dictation on screen live
+  - show the dictation on screen live
 - stop dictation
   - restore listener mode
-  - save dictation to file
-  - display full dictation on screen
+  - save the dictation to a file
+  - show the full dictation on screen
 
 ## Examples
 * "start dictation"


### PR DESCRIPTION
Rewrites the README for clarity, keeping every fact, link, and section.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the dictation skill’s purpose and its relationship to audio recording.
  * Documented behavior during start, conversation, and stop actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->