### PR TITLE
fix: correct inverted stop-dialog in handle_stop_dictation_intent

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -141,16 +141,16 @@ class DictationSkill(ConversationalSkill):
         """
         Handle a stop-dictation intent by notifying the user and stopping any active dictation.
         
-        If there is no active dictation for the session, speaks the "stop" dialog; otherwise speaks "not_dictating". Always invokes stop_dictation to ensure dictation is terminated and saved as appropriate.
-        
+        If there is no active dictation for the session, speaks the "not_dictating" dialog; otherwise speaks "stop". Always invokes stop_dictation to ensure dictation is terminated and saved as appropriate.
+
         Parameters:
             message: The incoming intent message containing session and intent data.
         """
         sess = SessionManager.get(message)
         if not self.is_dictating(sess):
-            self.speak_dialog("stop")
-        else:
             self.speak_dialog("not_dictating")
+        else:
+            self.speak_dialog("stop")
         self.stop_dictation(message)
 
     def can_stop(self, message: Message) -> bool:

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -1,5 +1,7 @@
 import unittest
+import tempfile
 from os.path import dirname
+from unittest.mock import patch
 
 from ovos_plugin_manager.skills import find_skill_plugins
 from ovos_utils.messagebus import FakeBus
@@ -73,3 +75,34 @@ class TestDictationState(unittest.TestCase):
         # a bare stop for an unknown session must restore the listener cleanly
         self.skill.stop_dictation(msg)
         self.assertFalse(self.skill.is_dictating(sess))
+
+    def test_stop_intent_dialog_when_dictating(self):
+        # regression test: when dictation IS active, the stop intent must
+        # confirm the stop, not claim dictation was never active
+        from ovos_bus_client.message import Message
+        from ovos_bus_client.session import Session, SessionManager
+        sess = Session("dictating-session")
+        start_msg = Message("start", {}, {"session": sess.serialize()})
+        self.skill.start_dictation(start_msg)
+        self.assertTrue(self.skill.is_dictating(SessionManager.get(start_msg)))
+
+        stop_msg = Message("stop", {}, {"session": sess.serialize()})
+        # stop_dictation writes a saved transcript under ~/Documents/dictations;
+        # redirect that to a throwaway tmpdir so the test never touches the
+        # real home directory
+        with tempfile.TemporaryDirectory() as fake_home:
+            with patch("os.path.expanduser", return_value=fake_home), \
+                    patch.object(self.skill, "speak_dialog") as mock_speak:
+                self.skill.handle_stop_dictation_intent(stop_msg)
+        mock_speak.assert_called_once_with("stop")
+
+    def test_stop_intent_dialog_when_not_dictating(self):
+        # regression test: when dictation was never active, the stop intent
+        # must say so, not confirm a stop that never happened
+        from ovos_bus_client.message import Message
+        from ovos_bus_client.session import Session
+        sess = Session("idle-session")
+        stop_msg = Message("stop", {}, {"session": sess.serialize()})
+        with patch.object(self.skill, "speak_dialog") as mock_speak:
+            self.skill.handle_stop_dictation_intent(stop_msg)
+        mock_speak.assert_called_once_with("not_dictating")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`handle_stop_dictation_intent` had its two dialogs swapped. When the user was actually dictating, the skill said "not dictating," and when they weren't dictating, it said "stop" as if it had just stopped something. The `if not self.is_dictating(sess):` branch called the wrong `speak_dialog` in each case. I checked this against `origin/dev` and the code matched exactly what's described here.

The fix just swaps the two calls back to the state they should report, without touching the condition itself, so it's a minimal one-line-each change.

I added two tests, `test_stop_intent_dialog_when_dictating` and `test_stop_intent_dialog_when_not_dictating`, that patch `speak_dialog` and check which dialog id gets used for each session state. Both fail on the unfixed code (wrong dialog picked in each case) and pass with the fix; the full suite is green at 14/14.

Note for the maintainer: PR #102 (entity wiring, still a blocked draft) also touches this repo, but this fix branches fresh off `origin/dev` and doesn't overlap with it.
